### PR TITLE
feat: Add GTM data layer for checkout and confirmation pages

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -208,6 +208,27 @@
         }
 
     </style>
+    <script>
+        // --- Data Layer for Google Tag Manager ---
+        window.dataLayer = window.dataLayer || [];
+        const checkoutDataForDL = JSON.parse(localStorage.getItem('checkoutData'));
+
+        if (checkoutDataForDL && checkoutDataForDL.cart) {
+            window.dataLayer.push({
+                event: 'begin_checkout',
+                ecommerce: {
+                    currency: 'USD',
+                    value: checkoutDataForDL.total,
+                    items: checkoutDataForDL.cart.map(item => ({
+                        item_id: item.title, // Using title as a unique identifier
+                        item_name: item.title,
+                        price: item.price,
+                        quantity: item.quantity
+                    }))
+                }
+            });
+        }
+    </script>
     <!-- Google Tag Manager -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/order-confirmation.html
+++ b/order-confirmation.html
@@ -178,6 +178,30 @@
             box-shadow: 0 10px 25px rgba(0,0,0,0.3);
         }
     </style>
+    <script>
+        // --- Data Layer for Google Tag Manager ---
+        window.dataLayer = window.dataLayer || [];
+        const orderDataJSON = localStorage.getItem('finalOrderData');
+
+        if (orderDataJSON) {
+            const orderData = JSON.parse(orderDataJSON);
+
+            window.dataLayer.push({
+                event: 'purchase',
+                ecommerce: {
+                    transaction_id: orderData.orderId,
+                    value: orderData.order.total,
+                    currency: 'USD',
+                    items: orderData.order.cart.map(item => ({
+                        item_id: item.title, // Using title as a unique identifier
+                        item_name: item.title,
+                        price: item.price,
+                        quantity: item.quantity
+                    }))
+                }
+            });
+        }
+    </script>
     <!-- Google Tag Manager -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
Adds a Google Tag Manager data layer to the 'Check Out' and 'Order Confirmation' pages.

- On `checkout.html`, a `begin_checkout` event is pushed to the data layer, containing the cart's contents and total value.
- On `order-confirmation.html`, a `purchase` event is pushed, including the transaction ID, total value, and items purchased.

This data is retrieved from `localStorage` and formatted according to Google's recommended e-commerce event structure.